### PR TITLE
Nix packaging using `poetry2nix`, per-axis interactive zooming.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ venv/
 build/
 dist/
 uniplot.egg-info/
+result

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "ros.distro": "humble"
-}

--- a/default.nix
+++ b/default.nix
@@ -10,10 +10,10 @@ let
   devpkgs = import <nixpkgs> {
     overlays = [ (import "${poetry2nix.outPath}/overlay.nix") ];
   };
-in devpkgs.poetry2nix.mkPoetryEditablePackages {
+in devpkgs.poetry2nix.mkPoetryPackages {
     projectDir = ./.;
     preferWheels = true;
     editablePackageSources = {
         uniplot = ./.;
-    }
+    };
 }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  poetry2nix = pkgs.fetchFromGitHub {
+    owner = "nix-community";
+    repo = "poetry2nix";
+    rev = "e0b44e9e2d3aa855d1dd77b06f067cd0e0c3860d";
+    sha256 = "sha256-puYyylgrBS4AFAHeyVRTjTUVD8DZdecJfymWJe7H438=";
+  };
+
+  devpkgs = import <nixpkgs> {
+    overlays = [ (import "${poetry2nix.outPath}/overlay.nix") ];
+  };
+in devpkgs.poetry2nix.mkPoetryEditablePackages {
+    projectDir = ./.;
+    preferWheels = true;
+    editablePackageSources = {
+        uniplot = ./.;
+    }
+}

--- a/run_interactive.sh
+++ b/run_interactive.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+python3 -c "import math; ys = [[math.sin(i/(10+i/50)) - math.sin(i/100) for i in range(1000)], [math.sin(i/(10+i/50)) - math.sin(i/100) - 1 for i in range(900)]]; from uniplot import plot; plot(ys, lines=True, x_unit='s', title='Double sine wave', interactive=True)"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,5 @@
-#!/bin/zsh
+#! /usr/bin/env nix-shell
+#! nix-shell -p zsh -i zsh
 
 # Script to run all tests, like a local CI pipeline
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,21 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  poetry2nix = pkgs.fetchFromGitHub {
+    owner = "nix-community";
+    repo = "poetry2nix";
+    rev = "e0b44e9e2d3aa855d1dd77b06f067cd0e0c3860d";
+    sha256 = "sha256-puYyylgrBS4AFAHeyVRTjTUVD8DZdecJfymWJe7H438=";
+  };
+
+  devpkgs = import <nixpkgs> {
+    overlays = [ (import "${poetry2nix.outPath}/overlay.nix") ];
+  };
+
+  uniplotEnv = devpkgs.poetry2nix.mkPoetryEnv {
+      projectDir = ./.;
+      preferWheels = true;
+      editablePackageSources = {
+          uniplot = ./.;
+      };
+  };
+in uniplotEnv.env

--- a/shell.nix
+++ b/shell.nix
@@ -1,21 +1,9 @@
 { pkgs ? import <nixpkgs> {} }:
 let
-  poetry2nix = pkgs.fetchFromGitHub {
-    owner = "nix-community";
-    repo = "poetry2nix";
-    rev = "e0b44e9e2d3aa855d1dd77b06f067cd0e0c3860d";
-    sha256 = "sha256-puYyylgrBS4AFAHeyVRTjTUVD8DZdecJfymWJe7H438=";
-  };
-
-  devpkgs = import <nixpkgs> {
-    overlays = [ (import "${poetry2nix.outPath}/overlay.nix") ];
-  };
-
-  uniplotEnv = devpkgs.poetry2nix.mkPoetryEnv {
-      projectDir = ./.;
-      preferWheels = true;
-      editablePackageSources = {
-          uniplot = ./.;
-      };
-  };
-in uniplotEnv.env
+  uniplot = pkgs.callPackage ./default.nix {inherit pkgs;};
+in pkgs.mkShell {
+  buildInputs = [
+    pkgs.poetry
+    (pkgs.python3.withPackages(ps: [] ++ uniplot.poetryPackages))
+  ];
+}

--- a/uniplot/getch.py
+++ b/uniplot/getch.py
@@ -1,0 +1,31 @@
+def _find_getch():
+    """
+    Read a single character input, without waiting for carriage return.
+
+    Ref.: https://stackoverflow.com/questions/510357/python-read-a-single-character-from-the-user
+    """
+    try:
+        import termios
+    except ImportError:
+        # Non-POSIX. Return msvcrt's (Windows') getch.
+        import msvcrt
+
+        return msvcrt.getch
+
+    # POSIX system. Create and return a getch that manipulates the tty.
+    import sys, tty
+
+    def _getch():
+        fd = sys.stdin.fileno()
+        old_settings = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            ch = sys.stdin.read(1)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+        return ch
+
+    return _getch
+
+
+getch = _find_getch()

--- a/uniplot/options.py
+++ b/uniplot/options.py
@@ -78,6 +78,18 @@ class Options:
     def zoom_out(self) -> None:
         self.__zoom_view(factor=-1)
 
+    def zoom_in_x(self) -> None:
+        self.__zoom_view(factor=1,y=False)
+
+    def zoom_out_x(self) -> None:
+        self.__zoom_view(factor=-1,y=False)
+
+    def zoom_in_y(self) -> None:
+        self.__zoom_view(factor=1,x=False)
+
+    def zoom_out_y(self) -> None:
+        self.__zoom_view(factor=-1,x=False)
+
     def reset_view(self) -> None:
         (self.x_min, self.x_max, self.y_min, self.y_max) = self._initial_bounds
 
@@ -100,11 +112,13 @@ class Options:
         self.y_min = self.y_min + step
         self.y_max = self.y_max + step
 
-    def __zoom_view(self, factor: int) -> None:
-        step = 0.1 * factor * (self.x_max - self.x_min)
-        self.x_min = self.x_min + step
-        self.x_max = self.x_max - step
+    def __zoom_view(self, factor: int, x: bool = True, y:bool = True) -> None:
+        if x:
+            step = 0.1 * factor * (self.x_max - self.x_min)
+            self.x_min = self.x_min + step
+            self.x_max = self.x_max - step
 
-        step = 0.1 * factor * (self.y_max - self.y_min)
-        self.y_min = self.y_min + step
-        self.y_max = self.y_max - step
+        if y:
+            step = 0.1 * factor * (self.y_max - self.y_min)
+            self.y_min = self.y_min + step
+            self.y_max = self.y_max - step

--- a/uniplot/uniplot.py
+++ b/uniplot/uniplot.py
@@ -58,8 +58,21 @@ def plot(ys: Any, xs: Optional[Any] = None, **kwargs) -> None:
             print(line)
 
         if options.interactive:
-            print("Move h/j/k/l, zoom u/n, or r to reset. ESC/q to quit")
-            key_pressed = getch().lower()
+            print("Move h/j/k/l, zoom u/n, zoom-y K/J, zoom-x H/L, or r to reset. ESC/q to quit")
+            key_pressed = getch()
+
+            # check case-sensitive keys for zooming
+            if key_pressed == "K":
+                options.zoom_in_y()
+            elif key_pressed == "J":
+                options.zoom_out_y()
+            elif key_pressed == "L":
+                options.zoom_in_x()
+            elif key_pressed == "H":
+                options.zoom_out_x()
+
+            # check case-insensitive keys for shifting
+            key_pressed = key_pressed.lower()
 
             if key_pressed == "h":
                 options.shift_view_left()

--- a/uniplot/uniplot.py
+++ b/uniplot/uniplot.py
@@ -6,6 +6,7 @@ from uniplot.multi_series import MultiSeries
 from uniplot.options import Options
 import uniplot.layer_assembly as layer_assembly
 import uniplot.plot_elements as elements
+from uniplot.getch import getch
 from uniplot.param_initializer import validate_and_transform_options
 from uniplot.axis_labels.extended_talbot_labels import extended_talbot_labels
 
@@ -55,6 +56,28 @@ def plot(ys: Any, xs: Optional[Any] = None, **kwargs) -> None:
             x_axis_labels, y_axis_labels, pixel_character_matrix, options
         ):
             print(line)
+
+        if options.interactive:
+            print("Move h/j/k/l, zoom u/n, or r to reset. ESC/q to quit")
+            key_pressed = getch().lower()
+
+            if key_pressed == "h":
+                options.shift_view_left()
+            elif key_pressed == "l":
+                options.shift_view_right()
+            elif key_pressed == "j":
+                options.shift_view_down()
+            elif key_pressed == "k":
+                options.shift_view_up()
+            elif key_pressed == "u":
+                options.zoom_in()
+            elif key_pressed == "n":
+                options.zoom_out()
+            elif key_pressed == "r":
+                options.reset_view()
+            elif key_pressed in ["q", "\x1b"]:
+                # q and Escape will end interactive mode
+                continue_looping = False
 
             loop_iteration += 1
 


### PR DESCRIPTION
This PR is just so I can review the changes I made, when Nix-ifying this repo.
There are some issues here - I screwed up the git history, so there's some stuff related to `getch` being added/deleted.
Also, I added `Shift-<H/J/K/L>` for per-axis interactive zooming.

## Notes for me
 - Nix's only role here is to make using `poetry` possible on NixOS platforms, and by extension the `uniplot` package itself.
   The development process using poetry is unchanged.
 - If Nix packaging is to be retained, the README.md should be updated to reflect this. This practically amounts to running `nix-shell` in the repo, after installing Nix, and then doing everything with poetry as usual.